### PR TITLE
Fix package version for gemfury

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-custom-scrollbars",
-  "version": "4.2.2-secondmeasurealpha.1",
+  "version": "4.2.1",
   "description": "React scrollbars component",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
- Override existing version of package (`react-custom-scrollbars` 4.2.1) instead of creating a second measure-specific version (`@secondmeasure/react-custom-scrollbars`)
- This ensures that throughout the dependency tree of skyfire, a single package version is used 